### PR TITLE
Bugfixes for Spark support

### DIFF
--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
@@ -392,7 +392,6 @@ public class ConfigUtils {
 
     public static void setIndexers(final RdfCloudTripleStoreConfiguration conf) {
 
-    	System.out.println("Testuing");
         final List<String> indexList = Lists.newArrayList();
         final List<String> optimizers = Lists.newArrayList();
 

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
@@ -392,6 +392,7 @@ public class ConfigUtils {
 
     public static void setIndexers(final RdfCloudTripleStoreConfiguration conf) {
 
+    	System.out.println("Testuing");
         final List<String> indexList = Lists.newArrayList();
         final List<String> optimizers = Lists.newArrayList();
 

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
@@ -288,6 +288,48 @@ public class EntityCentricIndex extends AbstractAccumuloIndexer {
         return new RyaStatement(subject, predicate, object, context,
                 null, columnVisibility, valueBytes, timestamp);
     }
+    
+    /**
+     * Return the RyaType of the Entity Centric Index row.
+     * @param key Row key, contains statement data
+     * @param value Row value
+     * @return The statement represented by the row
+     * @throws IOException if edge direction can't be extracted as expected.
+     * @throws RyaTypeResolverException if a type error occurs deserializing the statement's object.
+     */
+    public static RyaType getRyaType(Key key, Value value) throws RyaTypeResolverException, IOException {
+        assert key != null;
+        assert value != null;
+        byte[] entityBytes = key.getRowData().toArray();
+        byte[] data = key.getColumnQualifierData().toArray();
+
+        // main entity is either the subject or object
+        // data contains: column family , var name of other node , data of other node + datatype of object
+        int split = Bytes.indexOf(data, DELIM_BYTES);
+        byte[] edgeBytes = Arrays.copyOfRange(data, split + DELIM_BYTES.length, data.length);
+        split = Bytes.indexOf(edgeBytes, DELIM_BYTES);
+        String otherNodeVar = new String(Arrays.copyOf(edgeBytes, split));
+        byte[] typeBytes = Arrays.copyOfRange(edgeBytes,  edgeBytes.length - 2, edgeBytes.length);
+        byte[] objectBytes;
+        RyaURI subject;
+        RyaType object;
+        RyaType type = null;
+        switch (otherNodeVar) {
+            case "subject":
+                objectBytes = Bytes.concat(entityBytes, typeBytes);
+                object = RyaContext.getInstance().deserialize(objectBytes); //return this
+                type = object;
+                break;
+            case "object":
+                subject = new RyaURI(new String(entityBytes));//return this
+                type = subject;
+                break;
+            default:
+                throw new IOException("Failed to deserialize entity-centric index row. "
+                        + "Expected 'subject' or 'object', encountered: '" + otherNodeVar + "'");
+        }
+        return type;
+    }
 
     @Override
     public void init() {

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
@@ -25,6 +25,7 @@ import static mvm.rya.accumulo.AccumuloRdfConstants.EMPTY_VALUE;
 import static mvm.rya.api.RdfCloudTripleStoreConstants.DELIM_BYTES;
 import static mvm.rya.api.RdfCloudTripleStoreConstants.EMPTY_BYTES;
 import static mvm.rya.api.RdfCloudTripleStoreConstants.EMPTY_TEXT;
+import static mvm.rya.api.RdfCloudTripleStoreConstants.TYPE_DELIM_BYTES;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -259,23 +260,25 @@ public class EntityCentricIndex extends AbstractAccumuloIndexer {
         byte[] edgeBytes = Arrays.copyOfRange(data, split + DELIM_BYTES.length, data.length);
         split = Bytes.indexOf(edgeBytes, DELIM_BYTES);
         String otherNodeVar = new String(Arrays.copyOf(edgeBytes, split));
-        byte[] otherNodeBytes = Arrays.copyOfRange(edgeBytes,  split + DELIM_BYTES.length, edgeBytes.length - 2);
-        byte[] typeBytes = Arrays.copyOfRange(edgeBytes,  edgeBytes.length - 2, edgeBytes.length);
+        byte[] otherNodeBytes = Arrays.copyOfRange(edgeBytes,  split + DELIM_BYTES.length, edgeBytes.length);
+        split = Bytes.indexOf(otherNodeBytes, TYPE_DELIM_BYTES);
+        byte[] otherNodeData = Arrays.copyOf(otherNodeBytes,  split);
+        byte[] typeBytes = Arrays.copyOfRange(otherNodeBytes,  split, otherNodeBytes.length);
         byte[] objectBytes;
         RyaURI subject;
         RyaURI predicate = new RyaURI(new String(predicateBytes));
         RyaType object;
         RyaURI context = null;
-        // Expect either: entity=subject.data, otherNodeVar="object", otherNodeBytes={object.data, object.datatype_marker}
-        //            or: entity=object.data, otherNodeVar="subject", otherNodeBytes={subject.data, object.datatype_marker}
+        // Expect either: entity=subject.data, otherNodeVar="object", otherNodeBytes={object.data, object.datatype}
+        //            or: entity=object.data, otherNodeVar="subject", otherNodeBytes={subject.data, object.datatype}
         switch (otherNodeVar) {
             case "subject":
-                subject = new RyaURI(new String(otherNodeBytes));
+                subject = new RyaURI(new String(otherNodeData));
                 objectBytes = Bytes.concat(entityBytes, typeBytes);
                 break;
             case "object":
                 subject = new RyaURI(new String(entityBytes));
-                objectBytes = Bytes.concat(otherNodeBytes, typeBytes);
+                objectBytes = Bytes.concat(otherNodeData, typeBytes);
                 break;
             default:
                 throw new IOException("Failed to deserialize entity-centric index row. "
@@ -288,7 +291,7 @@ public class EntityCentricIndex extends AbstractAccumuloIndexer {
         return new RyaStatement(subject, predicate, object, context,
                 null, columnVisibility, valueBytes, timestamp);
     }
-    
+
     /**
      * Return the RyaType of the Entity Centric Index row.
      * @param key Row key, contains statement data
@@ -309,7 +312,9 @@ public class EntityCentricIndex extends AbstractAccumuloIndexer {
         byte[] edgeBytes = Arrays.copyOfRange(data, split + DELIM_BYTES.length, data.length);
         split = Bytes.indexOf(edgeBytes, DELIM_BYTES);
         String otherNodeVar = new String(Arrays.copyOf(edgeBytes, split));
-        byte[] typeBytes = Arrays.copyOfRange(edgeBytes,  edgeBytes.length - 2, edgeBytes.length);
+        byte[] otherNodeBytes = Arrays.copyOfRange(edgeBytes,  split + DELIM_BYTES.length, edgeBytes.length);
+        split = Bytes.indexOf(otherNodeBytes, TYPE_DELIM_BYTES);
+        byte[] typeBytes = Arrays.copyOfRange(otherNodeBytes,  split, otherNodeBytes.length);
         byte[] objectBytes;
         RyaURI subject;
         RyaType object;

--- a/mapreduce/pom.xml
+++ b/mapreduce/pom.xml
@@ -31,11 +31,11 @@ under the License.
     <name>Apache Rya MapReduce Tools</name>
 
     <dependencies>
-    	<dependency>
-		    <groupId>org.apache.spark</groupId>
-		    <artifactId>spark-graphx_2.11</artifactId>
-		    <version>1.6.2</version>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-graphx_2.11</artifactId>
+            <version>1.6.2</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>rya.api</artifactId>
@@ -116,6 +116,16 @@ under the License.
                         <executions>
                             <execution>
                                 <configuration>
+                                    <filters>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/*.SF</exclude>
+                                                <exclude>META-INF/*.DSA</exclude>
+                                                <exclude>META-INF/*.RSA</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
                                     <transformers>
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                     </transformers>

--- a/mapreduce/src/main/java/mvm/rya/accumulo/mr/GraphXEdgeInputFormat.java
+++ b/mapreduce/src/main/java/mvm/rya/accumulo/mr/GraphXEdgeInputFormat.java
@@ -1,0 +1,209 @@
+package mvm.rya.accumulo.mr;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map.Entry;
+
+import mvm.rya.accumulo.AccumuloRdfConfiguration;
+import mvm.rya.api.RdfCloudTripleStoreConstants.TABLE_LAYOUT;
+import mvm.rya.api.domain.RyaStatement;
+import mvm.rya.api.resolver.RyaTripleContext;
+import mvm.rya.api.resolver.triple.TripleRow;
+import mvm.rya.api.resolver.triple.TripleRowResolverException;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.mapreduce.AbstractInputFormat;
+import org.apache.accumulo.core.client.mapreduce.InputFormatBase;
+import org.apache.accumulo.core.client.mapreduce.RangeInputSplit;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.spark.graphx.Edge;
+
+/**
+ * Subclass of {@link AbstractInputFormat} for reading
+ * {@link RyaStatementWritable}s directly from a running Rya instance.
+ */
+@SuppressWarnings("rawtypes")
+public class GraphXEdgeInputFormat extends InputFormatBase<Object, Edge> {
+	/**
+	 * Instantiates a RecordReader for this InputFormat and a given task and
+	 * input split.
+	 * 
+	 * @param split
+	 *            Defines the portion of the input this RecordReader is
+	 *            responsible for.
+	 * @param context
+	 *            The context of the task.
+	 * @return A RecordReader that can be used to fetch RyaStatementWritables.
+	 */
+	@Override
+	public RecordReader<Object, Edge> createRecordReader(InputSplit split,
+			TaskAttemptContext context) {
+		return new RyaStatementRecordReader();
+	}
+
+	/**
+	 * Sets the table layout to use.
+	 * 
+	 * @param conf
+	 *            Configuration to set the layout in.
+	 * @param layout
+	 *            Statements will be read from the Rya table associated with
+	 *            this layout.
+	 */
+	public static void setTableLayout(Job conf, TABLE_LAYOUT layout) {
+		conf.getConfiguration().set(MRUtils.TABLE_LAYOUT_PROP, layout.name());
+	}
+
+	/**
+	 * Retrieves RyaStatementWritable objects from Accumulo tables.
+	 */
+	public class RyaStatementRecordReader extends
+			AbstractRecordReader<Object, Edge> {
+		private RyaTripleContext ryaContext;
+		private TABLE_LAYOUT tableLayout;
+
+		protected void setupIterators(TaskAttemptContext context,
+				Scanner scanner, String tableName, RangeInputSplit split) {
+		}
+
+		/**
+		 * Initializes the RecordReader.
+		 * 
+		 * @param inSplit
+		 *            Defines the portion of data to read.
+		 * @param attempt
+		 *            Context for this task attempt.
+		 * @throws IOException
+		 *             if thrown by the superclass's initialize method.
+		 */
+		@Override
+		public void initialize(InputSplit inSplit, TaskAttemptContext attempt)
+				throws IOException {
+			super.initialize(inSplit, attempt);
+			this.tableLayout = MRUtils.getTableLayout(
+					attempt.getConfiguration(), TABLE_LAYOUT.SPO);
+			// TODO verify that this is correct
+			this.ryaContext = RyaTripleContext
+					.getInstance(new AccumuloRdfConfiguration(attempt
+							.getConfiguration()));
+		}
+
+		/**
+		 * Load the next statement by converting the next Accumulo row to a
+		 * statement, and make the new (key,value) pair available for retrieval.
+		 * 
+		 * @return true if another (key,value) pair was fetched and is ready to
+		 *         be retrieved, false if there was none.
+		 * @throws IOException
+		 *             if a row was loaded but could not be converted to a
+		 *             statement.
+		 */
+		@Override
+		public boolean nextKeyValue() throws IOException {
+			if (!scannerIterator.hasNext())
+				return false;
+			Entry<Key, Value> entry = scannerIterator.next();
+			++numKeysRead;
+			currentKey = entry.getKey();
+			try {
+				currentK = currentKey.getRow();
+				RyaTypeWritable rtw = null;
+				RyaStatement stmt = this.ryaContext.deserializeTriple(
+						this.tableLayout, new TripleRow(entry.getKey().getRow()
+								.getBytes(), entry.getKey().getColumnFamily()
+								.getBytes(), entry.getKey()
+								.getColumnQualifier().getBytes(), entry
+								.getKey().getTimestamp(), entry.getKey()
+								.getColumnVisibility().getBytes(), entry
+								.getValue().get()));
+
+				String subjURI = stmt.getSubject().getDataType().toString();
+				String objURI = stmt.getObject().getDataType().toString();
+
+				// SHA-256 the string value and then generate a hashcode from
+				// the digested string, the collision ratio is less than 0.0001%
+				// using custom hash function should significantly reduce the
+				// collision ratio
+				MessageDigest messageDigest = MessageDigest
+						.getInstance("SHA-256");
+
+				messageDigest.update(subjURI.getBytes());
+				String encryptedString = new String(messageDigest.digest());
+				long subHash = hash(encryptedString);
+
+				messageDigest.update(objURI.getBytes());
+				encryptedString = new String(messageDigest.digest());
+				long objHash = hash(encryptedString);
+
+				Edge<RyaTypeWritable> writable = new Edge<RyaTypeWritable>(
+						subHash, objHash, rtw);
+				currentV = writable;
+			} catch (TripleRowResolverException | NoSuchAlgorithmException e) {
+				throw new IOException(e);
+			}
+			return true;
+		}
+
+		protected List<IteratorSetting> contextIterators(
+				TaskAttemptContext context, String tableName) {
+			return getIterators(context);
+		}
+
+		@Override
+		protected void setupIterators(TaskAttemptContext context,
+				Scanner scanner, String tableName,
+				org.apache.accumulo.core.client.mapreduce.RangeInputSplit split) {
+			List<IteratorSetting> iterators = null;
+
+			if (null == split) {
+				iterators = contextIterators(context, tableName);
+			} else {
+				iterators = split.getIterators();
+				if (null == iterators) {
+					iterators = contextIterators(context, tableName);
+				}
+			}
+
+			for (IteratorSetting iterator : iterators)
+				scanner.addScanIterator(iterator);
+		}
+
+	}
+
+	public static long hash(String string) {
+		long h = 1125899906842597L; // prime
+		int len = string.length();
+
+		for (int i = 0; i < len; i++) {
+			h = 31 * h + string.charAt(i);
+		}
+		return h;
+	}
+}

--- a/mapreduce/src/main/java/mvm/rya/accumulo/mr/GraphXEdgeInputFormat.java
+++ b/mapreduce/src/main/java/mvm/rya/accumulo/mr/GraphXEdgeInputFormat.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import mvm.rya.accumulo.AccumuloRdfConfiguration;
 import mvm.rya.api.RdfCloudTripleStoreConstants.TABLE_LAYOUT;
 import mvm.rya.api.domain.RyaStatement;
+import mvm.rya.api.domain.RyaType;
 import mvm.rya.api.resolver.RyaTripleContext;
 import mvm.rya.api.resolver.triple.TripleRow;
 import mvm.rya.api.resolver.triple.TripleRowResolverException;
@@ -36,7 +37,6 @@ import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.mapreduce.AbstractInputFormat;
 import org.apache.accumulo.core.client.mapreduce.InputFormatBase;
-import org.apache.accumulo.core.client.mapreduce.RangeInputSplit;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -54,7 +54,7 @@ public class GraphXEdgeInputFormat extends InputFormatBase<Object, Edge> {
 	/**
 	 * Instantiates a RecordReader for this InputFormat and a given task and
 	 * input split.
-	 * 
+	 *
 	 * @param split
 	 *            Defines the portion of the input this RecordReader is
 	 *            responsible for.
@@ -70,7 +70,7 @@ public class GraphXEdgeInputFormat extends InputFormatBase<Object, Edge> {
 
 	/**
 	 * Sets the table layout to use.
-	 * 
+	 *
 	 * @param conf
 	 *            Configuration to set the layout in.
 	 * @param layout
@@ -95,7 +95,7 @@ public class GraphXEdgeInputFormat extends InputFormatBase<Object, Edge> {
 
 		/**
 		 * Initializes the RecordReader.
-		 * 
+		 *
 		 * @param inSplit
 		 *            Defines the portion of data to read.
 		 * @param attempt
@@ -118,7 +118,7 @@ public class GraphXEdgeInputFormat extends InputFormatBase<Object, Edge> {
 		/**
 		 * Load the next statement by converting the next Accumulo row to a
 		 * statement, and make the new (key,value) pair available for retrieval.
-		 * 
+		 *
 		 * @return true if another (key,value) pair was fetched and is ready to
 		 *         be retrieved, false if there was none.
 		 * @throws IOException
@@ -134,7 +134,7 @@ public class GraphXEdgeInputFormat extends InputFormatBase<Object, Edge> {
 			currentKey = entry.getKey();
 			try {
 				currentK = currentKey.getRow();
-				RyaTypeWritable rtw = null;
+				RyaTypeWritable rtw = new RyaTypeWritable();
 				RyaStatement stmt = this.ryaContext.deserializeTriple(
 						this.tableLayout, new TripleRow(entry.getKey().getRow()
 								.getBytes(), entry.getKey().getColumnFamily()
@@ -144,28 +144,14 @@ public class GraphXEdgeInputFormat extends InputFormatBase<Object, Edge> {
 								.getColumnVisibility().getBytes(), entry
 								.getValue().get()));
 
-				String subjURI = stmt.getSubject().getDataType().toString();
-				String objURI = stmt.getObject().getDataType().toString();
-
-				// SHA-256 the string value and then generate a hashcode from
-				// the digested string, the collision ratio is less than 0.0001%
-				// using custom hash function should significantly reduce the
-				// collision ratio
-				MessageDigest messageDigest = MessageDigest
-						.getInstance("SHA-256");
-
-				messageDigest.update(subjURI.getBytes());
-				String encryptedString = new String(messageDigest.digest());
-				long subHash = hash(encryptedString);
-
-				messageDigest.update(objURI.getBytes());
-				encryptedString = new String(messageDigest.digest());
-				long objHash = hash(encryptedString);
+				long subHash = getVertexId(stmt.getSubject());
+				long objHash = getVertexId(stmt.getObject());
+				rtw.setRyaType(stmt.getPredicate());
 
 				Edge<RyaTypeWritable> writable = new Edge<RyaTypeWritable>(
 						subHash, objHash, rtw);
 				currentV = writable;
-			} catch (TripleRowResolverException | NoSuchAlgorithmException e) {
+			} catch (TripleRowResolverException e) {
 				throw new IOException(e);
 			}
 			return true;
@@ -195,6 +181,27 @@ public class GraphXEdgeInputFormat extends InputFormatBase<Object, Edge> {
 				scanner.addScanIterator(iterator);
 		}
 
+	}
+
+	public static long getVertexId(RyaType resource) throws IOException {
+		String uri = "";
+		if (resource != null) {
+			uri = resource.getData().toString();
+		}
+		try {
+			// SHA-256 the string value and then generate a hashcode from
+			// the digested string, the collision ratio is less than 0.0001%
+			// using custom hash function should significantly reduce the
+			// collision ratio
+			MessageDigest messageDigest = MessageDigest
+					.getInstance("SHA-256");
+			messageDigest.update(uri.getBytes());
+			String encryptedString = new String(messageDigest.digest());
+			return hash(encryptedString);
+		}
+		catch (NoSuchAlgorithmException e) {
+			throw new IOException(e);
+		}
 	}
 
 	public static long hash(String string) {

--- a/mapreduce/src/main/java/mvm/rya/accumulo/mr/GraphXInputFormat.java
+++ b/mapreduce/src/main/java/mvm/rya/accumulo/mr/GraphXInputFormat.java
@@ -1,0 +1,132 @@
+package mvm.rya.accumulo.mr;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+
+import mvm.rya.api.domain.RyaType;
+import mvm.rya.api.resolver.RyaTypeResolverException;
+import mvm.rya.indexing.accumulo.entity.EntityCentricIndex;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.mapreduce.InputFormatBase;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.user.WholeRowIterator;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+public class GraphXInputFormat extends InputFormatBase<Object, RyaTypeWritable> {
+
+	private static final int WHOLE_ROW_ITERATOR_PRIORITY = 23;
+
+	/**
+	 * Instantiates a RecordReader for this InputFormat and a given task and
+	 * input split.
+	 * 
+	 * @param split
+	 *            Defines the portion of the input this RecordReader is
+	 *            responsible for.
+	 * @param context
+	 *            The context of the task.
+	 * @return A RecordReader that can be used to fetch RyaStatementWritables.
+	 */
+	@Override
+	public RecordReader<Object, RyaTypeWritable> createRecordReader(
+			InputSplit split, TaskAttemptContext context) {
+		return new RyaStatementRecordReader();
+	}
+
+	
+	
+	/**
+	 * Retrieves RyaStatementWritable objects from Accumulo tables.
+	 */
+	public class RyaStatementRecordReader extends
+			AbstractRecordReader<Object, RyaTypeWritable> {
+		protected void setupIterators(TaskAttemptContext context,
+				Scanner scanner, String tableName,
+				@SuppressWarnings("deprecation") RangeInputSplit split) {
+			IteratorSetting iteratorSetting = new IteratorSetting(
+					WHOLE_ROW_ITERATOR_PRIORITY, WholeRowIterator.class);
+			scanner.addScanIterator(iteratorSetting);
+		}
+
+		/**
+		 * Initializes the RecordReader.
+		 * 
+		 * @param inSplit
+		 *            Defines the portion of data to read.
+		 * @param attempt
+		 *            Context for this task attempt.
+		 * @throws IOException
+		 *             if thrown by the superclass's initialize method.
+		 */
+		@Override
+		public void initialize(InputSplit inSplit, TaskAttemptContext attempt)
+				throws IOException {
+			super.initialize(inSplit, attempt);
+		}
+
+		/**
+		 * Load the next statement by converting the next Accumulo row to a
+		 * statement, and make the new (key,value) pair available for retrieval.
+		 * 
+		 * @return true if another (key,value) pair was fetched and is ready to
+		 *         be retrieved, false if there was none.
+		 * @throws IOException
+		 *             if a row was loaded but could not be converted to a
+		 *             statement.
+		 */
+		@Override
+		public boolean nextKeyValue() throws IOException {
+			if (!scannerIterator.hasNext())
+				return false;
+			Entry<Key, Value> entry = scannerIterator.next();
+			++numKeysRead;
+			currentKey = entry.getKey();
+
+			try {
+				currentK = currentKey.getRow();
+				SortedMap<Key, Value> wholeRow = WholeRowIterator.decodeRow(entry.getKey(), entry.getValue());
+				Key key = wholeRow.firstKey();
+				Value value = wholeRow.get(key);
+				RyaType type = EntityCentricIndex.getRyaType(key, value);
+				RyaTypeWritable writable = new RyaTypeWritable();
+				writable.setRyaType(type);
+				currentV = writable;
+			} catch (RyaTypeResolverException e) {
+				throw new IOException();
+			}
+			return true;
+		}
+
+		protected List<IteratorSetting> contextIterators(
+				TaskAttemptContext context, String tableName) {
+			return getIterators(context);
+		}
+
+		@Override
+		protected void setupIterators(TaskAttemptContext context,
+				Scanner scanner, String tableName,
+				org.apache.accumulo.core.client.mapreduce.RangeInputSplit split) {
+
+			List<IteratorSetting> iterators = null;
+
+			if (null == split) {
+				iterators = contextIterators(context, tableName);
+			} else {
+				iterators = split.getIterators();
+				if (null == iterators) {
+					iterators = contextIterators(context, tableName);
+				}
+			}
+
+			for (IteratorSetting iterator : iterators)
+				scanner.addScanIterator(iterator);
+		}
+	}
+}

--- a/mapreduce/src/main/java/mvm/rya/accumulo/mr/GraphXInputFormat.java
+++ b/mapreduce/src/main/java/mvm/rya/accumulo/mr/GraphXInputFormat.java
@@ -1,9 +1,27 @@
 package mvm.rya.accumulo.mr;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.SortedMap;
 
 import mvm.rya.api.domain.RyaType;
 import mvm.rya.api.resolver.RyaTypeResolverException;
@@ -26,7 +44,7 @@ public class GraphXInputFormat extends InputFormatBase<Object, RyaTypeWritable> 
 	/**
 	 * Instantiates a RecordReader for this InputFormat and a given task and
 	 * input split.
-	 * 
+	 *
 	 * @param split
 	 *            Defines the portion of the input this RecordReader is
 	 *            responsible for.
@@ -40,8 +58,8 @@ public class GraphXInputFormat extends InputFormatBase<Object, RyaTypeWritable> 
 		return new RyaStatementRecordReader();
 	}
 
-	
-	
+
+
 	/**
 	 * Retrieves RyaStatementWritable objects from Accumulo tables.
 	 */
@@ -57,7 +75,7 @@ public class GraphXInputFormat extends InputFormatBase<Object, RyaTypeWritable> 
 
 		/**
 		 * Initializes the RecordReader.
-		 * 
+		 *
 		 * @param inSplit
 		 *            Defines the portion of data to read.
 		 * @param attempt
@@ -74,7 +92,7 @@ public class GraphXInputFormat extends InputFormatBase<Object, RyaTypeWritable> 
 		/**
 		 * Load the next statement by converting the next Accumulo row to a
 		 * statement, and make the new (key,value) pair available for retrieval.
-		 * 
+		 *
 		 * @return true if another (key,value) pair was fetched and is ready to
 		 *         be retrieved, false if there was none.
 		 * @throws IOException
@@ -90,13 +108,10 @@ public class GraphXInputFormat extends InputFormatBase<Object, RyaTypeWritable> 
 			currentKey = entry.getKey();
 
 			try {
-				currentK = currentKey.getRow();
-				SortedMap<Key, Value> wholeRow = WholeRowIterator.decodeRow(entry.getKey(), entry.getValue());
-				Key key = wholeRow.firstKey();
-				Value value = wholeRow.get(key);
-				RyaType type = EntityCentricIndex.getRyaType(key, value);
+				RyaType type = EntityCentricIndex.getRyaType(currentKey, entry.getValue());
 				RyaTypeWritable writable = new RyaTypeWritable();
 				writable.setRyaType(type);
+				currentK = GraphXEdgeInputFormat.getVertexId(type);
 				currentV = writable;
 			} catch (RyaTypeResolverException e) {
 				throw new IOException();

--- a/mapreduce/src/main/java/mvm/rya/accumulo/mr/RyaTypeWritable.java
+++ b/mapreduce/src/main/java/mvm/rya/accumulo/mr/RyaTypeWritable.java
@@ -1,0 +1,74 @@
+package mvm.rya.accumulo.mr;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import mvm.rya.api.RdfCloudTripleStoreConstants;
+import mvm.rya.api.domain.RyaStatement;
+import mvm.rya.api.domain.RyaType;
+import mvm.rya.api.resolver.triple.TripleRow;
+import mvm.rya.api.resolver.triple.TripleRowResolverException;
+
+import org.apache.hadoop.io.WritableComparable;
+import org.openrdf.model.URI;
+import org.openrdf.model.impl.ValueFactoryImpl;
+
+public class RyaTypeWritable implements WritableComparable<RyaTypeWritable>{
+
+	private RyaType ryatype;
+	
+	/**
+     * Read part of a statement from an input stream.
+     * @param dataInput Stream for reading serialized statements.
+     * @return The next individual field, as a byte array.
+     * @throws IOException if reading from the stream fails.
+     */
+    protected byte[] read(DataInput dataInput) throws IOException {
+        if (dataInput.readBoolean()) {
+            int len = dataInput.readInt();
+            byte[] bytes = new byte[len];
+            dataInput.readFully(bytes);
+            return bytes;
+        }else {
+            return null;
+        }
+    }
+	
+	@Override
+	public void readFields(DataInput dataInput) throws IOException {
+		ValueFactoryImpl vfi = new ValueFactoryImpl();
+		String data = dataInput.readLine();
+		String dataTypeString = dataInput.readLine();
+		URI dataType = vfi.createURI(dataTypeString);
+		ryatype.setData(data);
+		ryatype.setDataType(dataType);
+	}
+
+	@Override
+	public void write(DataOutput dataOutput) throws IOException {
+		dataOutput.writeChars(ryatype.getData());
+		dataOutput.writeChars(ryatype.getDataType().toString());
+	}
+	
+	/**
+     * Gets the contained RyaStatement.
+     * @return The statement represented by this RyaStatementWritable.
+     */
+    public RyaType getRyaType() {
+        return ryatype;
+    }
+    /**
+     * Sets the contained RyaStatement.
+     * @param   ryaStatement    The statement to be represented by this
+     *                          RyaStatementWritable.
+     */
+    public void setRyaType(RyaType ryatype) {
+        this.ryatype = ryatype;
+    }
+
+	@Override
+	public int compareTo(RyaTypeWritable o) {
+		return ryatype.compareTo(o.ryatype);
+	}
+}

--- a/mapreduce/src/main/java/mvm/rya/accumulo/mr/RyaTypeWritable.java
+++ b/mapreduce/src/main/java/mvm/rya/accumulo/mr/RyaTypeWritable.java
@@ -1,14 +1,29 @@
 package mvm.rya.accumulo.mr;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import mvm.rya.api.RdfCloudTripleStoreConstants;
-import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.api.domain.RyaType;
-import mvm.rya.api.resolver.triple.TripleRow;
-import mvm.rya.api.resolver.triple.TripleRowResolverException;
 
 import org.apache.hadoop.io.WritableComparable;
 import org.openrdf.model.URI;
@@ -16,9 +31,9 @@ import org.openrdf.model.impl.ValueFactoryImpl;
 
 public class RyaTypeWritable implements WritableComparable<RyaTypeWritable>{
 
-	private RyaType ryatype;
-	
-	/**
+    private RyaType ryatype;
+
+    /**
      * Read part of a statement from an input stream.
      * @param dataInput Stream for reading serialized statements.
      * @return The next individual field, as a byte array.
@@ -34,24 +49,24 @@ public class RyaTypeWritable implements WritableComparable<RyaTypeWritable>{
             return null;
         }
     }
-	
-	@Override
-	public void readFields(DataInput dataInput) throws IOException {
-		ValueFactoryImpl vfi = new ValueFactoryImpl();
-		String data = dataInput.readLine();
-		String dataTypeString = dataInput.readLine();
-		URI dataType = vfi.createURI(dataTypeString);
-		ryatype.setData(data);
-		ryatype.setDataType(dataType);
-	}
 
-	@Override
-	public void write(DataOutput dataOutput) throws IOException {
-		dataOutput.writeChars(ryatype.getData());
-		dataOutput.writeChars(ryatype.getDataType().toString());
-	}
-	
-	/**
+    @Override
+    public void readFields(DataInput dataInput) throws IOException {
+        ValueFactoryImpl vfi = new ValueFactoryImpl();
+        String data = dataInput.readLine();
+        String dataTypeString = dataInput.readLine();
+        URI dataType = vfi.createURI(dataTypeString);
+        ryatype.setData(data);
+        ryatype.setDataType(dataType);
+    }
+
+    @Override
+    public void write(DataOutput dataOutput) throws IOException {
+        dataOutput.writeChars(ryatype.getData());
+        dataOutput.writeChars(ryatype.getDataType().toString());
+    }
+
+    /**
      * Gets the contained RyaStatement.
      * @return The statement represented by this RyaStatementWritable.
      */
@@ -67,8 +82,42 @@ public class RyaTypeWritable implements WritableComparable<RyaTypeWritable>{
         this.ryatype = ryatype;
     }
 
-	@Override
-	public int compareTo(RyaTypeWritable o) {
-		return ryatype.compareTo(o.ryatype);
-	}
+    @Override
+    public int compareTo(RyaTypeWritable o) {
+        return ryatype.compareTo(o.ryatype);
+    }
+
+    /**
+     * Tests for equality using the equals method of the enclosed RyaType.
+     * @param   o   Object to compare with
+     * @return  true if both objects are RyaTypeWritables containing equivalent
+     *          RyaTypes.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null || !(o instanceof RyaTypeWritable)) {
+            return false;
+        }
+        RyaType rtThis = ryatype;
+        RyaType rtOther = ((RyaTypeWritable) o).ryatype;
+        if (rtThis == null) {
+            return rtOther == null;
+        }
+        else {
+            return rtThis.equals(rtOther);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        if (ryatype == null) {
+            return 0;
+        }
+        else {
+            return ryatype.hashCode();
+        }
+    }
 }

--- a/mapreduce/src/test/java/mvm/rya/accumulo/mr/GraphXEdgeInputFormatTest.java
+++ b/mapreduce/src/test/java/mvm/rya/accumulo/mr/GraphXEdgeInputFormatTest.java
@@ -75,9 +75,9 @@ public class GraphXEdgeInputFormatTest {
     }
 
     @SuppressWarnings("rawtypes")
-	@Test
+    @Test
     public void testInputFormat() throws Exception {
-    	RyaStatement input = RyaStatement.builder()
+        RyaStatement input = RyaStatement.builder()
             .setSubject(new RyaURI("http://www.google.com"))
             .setPredicate(new RyaURI("http://some_other_uri"))
             .setObject(new RyaURI("http://www.yahoo.com"))
@@ -119,7 +119,7 @@ public class GraphXEdgeInputFormatTest {
             Edge writable = (Edge) ryaStatementRecordReader.getCurrentValue();
             long srcId = writable.srcId();
             long destId = writable.dstId();
-			RyaTypeWritable rtw = null;
+            RyaTypeWritable rtw = null;
             Object text = ryaStatementRecordReader.getCurrentKey();
             Edge<RyaTypeWritable> edge = new Edge<RyaTypeWritable>(srcId, destId, rtw);
             results.add(edge);

--- a/mapreduce/src/test/java/mvm/rya/accumulo/mr/GraphXInputFormatTest.java
+++ b/mapreduce/src/test/java/mvm/rya/accumulo/mr/GraphXInputFormatTest.java
@@ -22,17 +22,17 @@ import java.util.List;
 
 import mvm.rya.accumulo.AccumuloRdfConfiguration;
 import mvm.rya.accumulo.AccumuloRyaDAO;
-import mvm.rya.accumulo.mr.RyaInputFormat.RyaStatementRecordReader;
-import mvm.rya.api.RdfCloudTripleStoreConstants.TABLE_LAYOUT;
+import mvm.rya.accumulo.mr.GraphXInputFormat.RyaStatementRecordReader;
 import mvm.rya.api.domain.RyaStatement;
+import mvm.rya.api.domain.RyaType;
 import mvm.rya.api.domain.RyaURI;
+import mvm.rya.indexing.accumulo.ConfigUtils;
+import mvm.rya.indexing.accumulo.entity.EntityCentricIndex;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
-import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
 import org.apache.accumulo.core.client.mock.MockInstance;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobContext;
@@ -45,34 +45,30 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class RyaInputFormatTest {
+public class GraphXInputFormatTest {
 
-    static String username = "root", table = "rya_spo";
-    static PasswordToken password = new PasswordToken("");
+	private String username = "root", table = "rya_eci";
+    private PasswordToken password = new PasswordToken("");
 
-    static Instance instance;
-    static AccumuloRyaDAO apiImpl;
+    private Instance instance;
+    private AccumuloRyaDAO apiImpl;
 
-    @BeforeClass
-    public static void init() throws Exception {
-        instance = new MockInstance(RyaInputFormatTest.class.getName() + ".mock_instance");
+    @Before
+    public void init() throws Exception {
+        instance = new MockInstance(GraphXInputFormatTest.class.getName() + ".mock_instance");
         Connector connector = instance.getConnector(username, password);
         connector.tableOperations().create(table);
 
         AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
         conf.setTablePrefix("rya_");
         conf.setDisplayQueryPlan(false);
+        conf.setBoolean("sc.use_entity", true);
 
         apiImpl = new AccumuloRyaDAO();
         apiImpl.setConf(conf);
         apiImpl.setConnector(connector);
-    }
-
-    @Before
-    public void before() throws Exception {
         apiImpl.init();
     }
 
@@ -83,9 +79,7 @@ public class RyaInputFormatTest {
 
     @Test
     public void testInputFormat() throws Exception {
-
-
-        RyaStatement input = RyaStatement.builder()
+    	RyaStatement input = RyaStatement.builder()
             .setSubject(new RyaURI("http://www.google.com"))
             .setPredicate(new RyaURI("http://some_other_uri"))
             .setObject(new RyaURI("http://www.yahoo.com"))
@@ -97,17 +91,16 @@ public class RyaInputFormatTest {
 
         Job jobConf = Job.getInstance();
 
-        RyaInputFormat.setMockInstance(jobConf, instance.getInstanceName());
-        RyaInputFormat.setConnectorInfo(jobConf, username, password);
-        RyaInputFormat.setTableLayout(jobConf, TABLE_LAYOUT.SPO);
+        GraphXInputFormat.setMockInstance(jobConf, instance.getInstanceName());
+        GraphXInputFormat.setConnectorInfo(jobConf, username, password);
+        GraphXInputFormat.setInputTableName(jobConf, table);
+        GraphXInputFormat.setInputTableName(jobConf, table);
 
-        AccumuloInputFormat.setInputTableName(jobConf, table);
-        AccumuloInputFormat.setInputTableName(jobConf, table);
-        AccumuloInputFormat.setScanIsolation(jobConf, false);
-        AccumuloInputFormat.setLocalIterators(jobConf, false);
-        AccumuloInputFormat.setOfflineTableScan(jobConf, false);
+        GraphXInputFormat.setScanIsolation(jobConf, false);
+        GraphXInputFormat.setLocalIterators(jobConf, false);
+        GraphXInputFormat.setOfflineTableScan(jobConf, false);
 
-        RyaInputFormat inputFormat = new RyaInputFormat();
+        GraphXInputFormat inputFormat = new GraphXInputFormat();
 
         JobContext context = new JobContextImpl(jobConf.getConfiguration(), jobConf.getJobID());
 
@@ -117,32 +110,35 @@ public class RyaInputFormatTest {
 
         TaskAttemptContext taskAttemptContext = new TaskAttemptContextImpl(context.getConfiguration(), new TaskAttemptID(new TaskID(), 1));
 
-        RecordReader<Text, RyaStatementWritable> reader = inputFormat.createRecordReader(splits.get(0), taskAttemptContext);
+        RecordReader<Object, RyaTypeWritable> reader = inputFormat.createRecordReader(splits.get(0), taskAttemptContext);
 
         RyaStatementRecordReader ryaStatementRecordReader = (RyaStatementRecordReader)reader;
         ryaStatementRecordReader.initialize(splits.get(0), taskAttemptContext);
 
-        List<RyaStatement> results = new ArrayList<RyaStatement>();
+        List<RyaType> results = new ArrayList<RyaType>();
+        System.out.println("before while");
         while(ryaStatementRecordReader.nextKeyValue()) {
-            RyaStatementWritable writable = ryaStatementRecordReader.getCurrentValue();
-            RyaStatement value = writable.getRyaStatement();
-            Text text = ryaStatementRecordReader.getCurrentKey();
-            RyaStatement stmt = RyaStatement.builder()
-                .setSubject(value.getSubject())
-                .setPredicate(value.getPredicate())
-                .setObject(value.getObject())
-                .setContext(value.getContext())
-                .setQualifier(value.getQualifer())
-                .setColumnVisibility(value.getColumnVisibility())
-                .setValue(value.getValue())
-                .build();
-            results.add(stmt);
-
+        	System.out.println("in while");
+            RyaTypeWritable writable = ryaStatementRecordReader.getCurrentValue();
+            RyaType value = writable.getRyaType();
+            Object text = ryaStatementRecordReader.getCurrentKey();
+            RyaType type = new RyaType();
+            type.setData(value.getData());
+            type.setDataType(value.getDataType());
+            results.add(type);
+            
+            System.out.println(value.getData());
+            System.out.println(value.getDataType());
+            System.out.println(results);
+            System.out.println(type);
             System.out.println(text);
             System.out.println(value);
         }
+        System.out.println("after while");
 
-        Assert.assertTrue(results.size() == 2);
-        Assert.assertTrue(results.contains(input));
+        System.out.println(results.size());
+        System.out.println(results);
+//        Assert.assertTrue(results.size() == 2);
+//        Assert.assertTrue(results.contains(input));
     }
 }

--- a/mapreduce/src/test/java/mvm/rya/accumulo/mr/GraphXInputFormatTest.java
+++ b/mapreduce/src/test/java/mvm/rya/accumulo/mr/GraphXInputFormatTest.java
@@ -26,8 +26,6 @@ import mvm.rya.accumulo.mr.GraphXInputFormat.RyaStatementRecordReader;
 import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.api.domain.RyaType;
 import mvm.rya.api.domain.RyaURI;
-import mvm.rya.indexing.accumulo.ConfigUtils;
-import mvm.rya.indexing.accumulo.entity.EntityCentricIndex;
 
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
@@ -49,7 +47,7 @@ import org.junit.Test;
 
 public class GraphXInputFormatTest {
 
-	private String username = "root", table = "rya_eci";
+    private String username = "root", table = "rya_eci";
     private PasswordToken password = new PasswordToken("");
 
     private Instance instance;
@@ -79,7 +77,7 @@ public class GraphXInputFormatTest {
 
     @Test
     public void testInputFormat() throws Exception {
-    	RyaStatement input = RyaStatement.builder()
+        RyaStatement input = RyaStatement.builder()
             .setSubject(new RyaURI("http://www.google.com"))
             .setPredicate(new RyaURI("http://some_other_uri"))
             .setObject(new RyaURI("http://www.yahoo.com"))
@@ -118,7 +116,7 @@ public class GraphXInputFormatTest {
         List<RyaType> results = new ArrayList<RyaType>();
         System.out.println("before while");
         while(ryaStatementRecordReader.nextKeyValue()) {
-        	System.out.println("in while");
+            System.out.println("in while");
             RyaTypeWritable writable = ryaStatementRecordReader.getCurrentValue();
             RyaType value = writable.getRyaType();
             Object text = ryaStatementRecordReader.getCurrentKey();
@@ -126,7 +124,7 @@ public class GraphXInputFormatTest {
             type.setData(value.getData());
             type.setDataType(value.getDataType());
             results.add(type);
-            
+
             System.out.println(value.getData());
             System.out.println(value.getDataType());
             System.out.println(results);

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@ under the License.
         <module>osgi</module>
         <module>pig</module>
         <module>sail</module>
+        <module>spark</module>
         <module>web</module>
     </modules>
     <properties>
@@ -564,8 +565,8 @@ under the License.
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <encoding>${project.build.sourceEncoding}</encoding>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -27,14 +27,19 @@ under the License.
         <version>3.2.10-SNAPSHOT</version>
     </parent>
 
-    <artifactId>rya.mapreduce</artifactId>
+    <artifactId>rya.spark</artifactId>
     <name>Apache Rya MapReduce Tools</name>
 
     <dependencies>
-    	<dependency>
+	    <dependency>
 		    <groupId>org.apache.spark</groupId>
 		    <artifactId>spark-graphx_2.11</artifactId>
 		    <version>1.6.2</version>
+		</dependency>
+	    <dependency>
+		    <groupId>org.apache.spark</groupId>
+		    <artifactId>spark-core_2.11</artifactId>
+		    <version>1.2.2</version>
 		</dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>
@@ -47,6 +52,10 @@ under the License.
         <dependency>
             <groupId>org.apache.rya</groupId>
             <artifactId>rya.indexing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.mapreduce</artifactId>
         </dependency>
 
         <dependency>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -28,7 +28,7 @@ under the License.
     </parent>
 
     <artifactId>rya.spark</artifactId>
-    <name>Apache Rya MapReduce Tools</name>
+    <name>Apache Rya Spark Support</name>
 
     <dependencies>
 	    <dependency>
@@ -39,7 +39,7 @@ under the License.
 	    <dependency>
 		    <groupId>org.apache.spark</groupId>
 		    <artifactId>spark-core_2.11</artifactId>
-		    <version>1.2.2</version>
+		    <version>1.6.2</version>
 		</dependency>
         <dependency>
             <groupId>org.apache.rya</groupId>

--- a/spark/src/main/java/mvm/rya/accumulo/spark/GraphXGraphGenerator.java
+++ b/spark/src/main/java/mvm/rya/accumulo/spark/GraphXGraphGenerator.java
@@ -1,0 +1,188 @@
+package mvm.rya.accumulo.spark;
+
+import java.io.IOException;
+
+import mvm.rya.accumulo.AccumuloRdfConstants;
+import mvm.rya.accumulo.mr.GraphXEdgeInputFormat;
+import mvm.rya.accumulo.mr.GraphXInputFormat;
+import mvm.rya.accumulo.mr.MRUtils;
+import mvm.rya.accumulo.mr.RyaInputFormat;
+import mvm.rya.accumulo.mr.RyaTypeWritable;
+import mvm.rya.api.RdfCloudTripleStoreConfiguration;
+import mvm.rya.api.RdfCloudTripleStoreConstants;
+import mvm.rya.api.RdfCloudTripleStoreConstants.TABLE_LAYOUT;
+import mvm.rya.indexing.accumulo.ConfigUtils;
+import mvm.rya.indexing.accumulo.entity.EntityCentricIndex;
+
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.ClientConfiguration;
+import org.apache.accumulo.core.client.ClientConfiguration.ClientProperty;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.graphx.Edge;
+import org.apache.spark.graphx.Graph;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.storage.StorageLevel;
+
+import scala.Tuple2;
+import scala.reflect.ClassTag;
+
+import com.google.common.base.Preconditions;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class GraphXGraphGenerator {
+	
+	public String zk;
+	public String instance;
+	public String userName;
+	public String pwd;
+	public boolean mock;
+	public String tablePrefix;
+	public Authorizations authorizations;
+	
+	public RDD<Tuple2<Object, RyaTypeWritable>> getVertexRDD(SparkContext sc, Configuration conf) throws IOException, AccumuloSecurityException{
+		// Load configuration parameters
+        zk = MRUtils.getACZK(conf);
+        instance = MRUtils.getACInstance(conf);
+        userName = MRUtils.getACUserName(conf);
+        pwd = MRUtils.getACPwd(conf);
+        mock = MRUtils.getACMock(conf, false);
+        tablePrefix = MRUtils.getTablePrefix(conf);
+        // Set authorizations if specified
+        String authString = conf.get(MRUtils.AC_AUTH_PROP);
+		if (authString != null && !authString.isEmpty()) {
+            authorizations = new Authorizations(authString.split(","));
+            conf.set(ConfigUtils.CLOUDBASE_AUTHS, authString); // for consistency
+        }
+        else {
+            authorizations = AccumuloRdfConstants.ALL_AUTHORIZATIONS;
+        }
+        // Set table prefix to the default if not set
+        if (tablePrefix == null) {
+            tablePrefix = RdfCloudTripleStoreConstants.TBL_PRFX_DEF;
+            MRUtils.setTablePrefix(conf, tablePrefix);
+        }
+        // Check for required configuration parameters
+        Preconditions.checkNotNull(instance, "Accumulo instance name [" + MRUtils.AC_INSTANCE_PROP + "] not set.");
+        Preconditions.checkNotNull(userName, "Accumulo username [" + MRUtils.AC_USERNAME_PROP + "] not set.");
+        Preconditions.checkNotNull(pwd, "Accumulo password [" + MRUtils.AC_PWD_PROP + "] not set.");
+        Preconditions.checkNotNull(tablePrefix, "Table prefix [" + MRUtils.TABLE_PREFIX_PROPERTY + "] not set.");
+        RdfCloudTripleStoreConstants.prefixTables(tablePrefix);
+        // If connecting to real accumulo, set additional parameters and require zookeepers
+        if (!mock) conf.set(ConfigUtils.CLOUDBASE_ZOOKEEPERS, zk); // for consistency
+        // Ensure consistency between alternative configuration properties
+        conf.set(ConfigUtils.CLOUDBASE_INSTANCE, instance);
+        conf.set(ConfigUtils.CLOUDBASE_USER, userName);
+        conf.set(ConfigUtils.CLOUDBASE_PASSWORD, pwd);
+        conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, mock);
+        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, tablePrefix);
+
+		Job job = Job.getInstance(conf, sc.appName());
+		
+		ClientConfiguration clientConfig = new ClientConfiguration().with(ClientProperty.INSTANCE_NAME, instance).with(ClientProperty.INSTANCE_ZK_HOST, zk);
+		
+		//maybe ask conf for correct suffix?
+		GraphXInputFormat.setInputTableName(job, EntityCentricIndex.CONF_TABLE_SUFFIX);
+		GraphXInputFormat.setConnectorInfo(job, userName, pwd);
+		GraphXInputFormat.setZooKeeperInstance(job, clientConfig);
+		GraphXInputFormat.setScanAuthorizations(job, authorizations);
+		
+		return sc.newAPIHadoopRDD(job.getConfiguration(), GraphXInputFormat.class, Object.class, RyaTypeWritable.class);
+	}
+	
+	public RDD<Tuple2<Object, Edge>> getEdgeRDD(SparkContext sc, Configuration conf) throws IOException, AccumuloSecurityException{
+		// Load configuration parameters
+        zk = MRUtils.getACZK(conf);
+        instance = MRUtils.getACInstance(conf);
+        userName = MRUtils.getACUserName(conf);
+        pwd = MRUtils.getACPwd(conf);
+        mock = MRUtils.getACMock(conf, false);
+        tablePrefix = MRUtils.getTablePrefix(conf);
+        // Set authorizations if specified
+        String authString = conf.get(MRUtils.AC_AUTH_PROP);
+		if (authString != null && !authString.isEmpty()) {
+            authorizations = new Authorizations(authString.split(","));
+            conf.set(ConfigUtils.CLOUDBASE_AUTHS, authString); // for consistency
+        }
+        else {
+            authorizations = AccumuloRdfConstants.ALL_AUTHORIZATIONS;
+        }
+        // Set table prefix to the default if not set
+        if (tablePrefix == null) {
+            tablePrefix = RdfCloudTripleStoreConstants.TBL_PRFX_DEF;
+            MRUtils.setTablePrefix(conf, tablePrefix);
+        }
+        // Check for required configuration parameters
+        Preconditions.checkNotNull(instance, "Accumulo instance name [" + MRUtils.AC_INSTANCE_PROP + "] not set.");
+        Preconditions.checkNotNull(userName, "Accumulo username [" + MRUtils.AC_USERNAME_PROP + "] not set.");
+        Preconditions.checkNotNull(pwd, "Accumulo password [" + MRUtils.AC_PWD_PROP + "] not set.");
+        Preconditions.checkNotNull(tablePrefix, "Table prefix [" + MRUtils.TABLE_PREFIX_PROPERTY + "] not set.");
+        RdfCloudTripleStoreConstants.prefixTables(tablePrefix);
+        // If connecting to real accumulo, set additional parameters and require zookeepers
+        if (!mock) conf.set(ConfigUtils.CLOUDBASE_ZOOKEEPERS, zk); // for consistency
+        // Ensure consistency between alternative configuration properties
+        conf.set(ConfigUtils.CLOUDBASE_INSTANCE, instance);
+        conf.set(ConfigUtils.CLOUDBASE_USER, userName);
+        conf.set(ConfigUtils.CLOUDBASE_PASSWORD, pwd);
+        conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, mock);
+        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, tablePrefix);
+
+		Job job = Job.getInstance(conf, sc.appName());
+		
+		ClientConfiguration clientConfig = new ClientConfiguration().with(ClientProperty.INSTANCE_NAME, instance).with(ClientProperty.INSTANCE_ZK_HOST, zk);
+		
+		RyaInputFormat.setTableLayout(job, TABLE_LAYOUT.SPO);
+		RyaInputFormat.setConnectorInfo(job, userName, pwd);
+		RyaInputFormat.setZooKeeperInstance(job, clientConfig);
+		RyaInputFormat.setScanAuthorizations(job, authorizations);
+		return sc.newAPIHadoopRDD(job.getConfiguration(), GraphXEdgeInputFormat.class, Object.class, Edge.class);
+	}
+	
+	public Graph<RyaTypeWritable, RyaTypeWritable> createGraph(SparkContext sc, Configuration conf) throws IOException, AccumuloSecurityException{
+		StorageLevel storageLvl1 = StorageLevel.MEMORY_ONLY();
+		StorageLevel storageLvl2 = StorageLevel.MEMORY_ONLY();
+		ClassTag<RyaTypeWritable> RTWTag = null;
+		RyaTypeWritable rtw = null;
+		RDD<Tuple2<Object, RyaTypeWritable>> vertexRDD = getVertexRDD(sc, conf);
+		
+		RDD<Tuple2<Object, Edge>> edgeRDD = getEdgeRDD(sc, conf);
+		JavaRDD<Tuple2<Object, Edge>> jrddTuple = edgeRDD.toJavaRDD();
+		JavaRDD<Edge<RyaTypeWritable>> jrdd = jrddTuple.map(tuple -> tuple._2);
+		
+		RDD<Edge<RyaTypeWritable>> goodERDD = JavaRDD.toRDD(jrdd);
+		
+		return Graph.apply(vertexRDD, goodERDD, rtw, storageLvl1, storageLvl2, RTWTag, RTWTag);
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+}


### PR DESCRIPTION
In playing around with this, I made some small changes to get it working:
- parent pom: Added spark project, switched to Java 1.8 (needed to compile this branch, matches change in master)
- spark pom: Changed project name, changed version to match mapreduce pom's spark dependency (1.6.2)
- mapreduce pom: Exclude dependencies' jar metadata from the shaded jar
- GraphXEdgeInputFormat: Pull the hash function out of nextKeyValue and make it accessible
- GraphXInputFormat: Use the same hash function for vertex IDs
- GraphXGraphGenerator: Set table names based on config, use PasswordToken, set ClassTag,
- RyaTypeWritable: Needed equals, hashCode
- EntityCentricIndex: Fixed deserialization logic to handle arbitrary datatypes
- misc.: Apache license, whitespace fixes (more consistent within files), removed debug statement, removed some unused imports

I've been able to use it successfully for datasets up to the low millions of triples, but had some problems trying to scale up to tens of millions. It seemed to spend a lot of time in garbage collection; reducing the number of nested objects might be a worthwhile goal at some point.
